### PR TITLE
task/DDA-0007 -- integration tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,7 +35,7 @@ jobs:
         poetry install
     - name: Run Server-side unit tests and generate coverage report
       run: |
-        poetry run pytest democratizing 
+        poetry run pytest -c unit_test.ini democratizing 
   Server_Side_Linting:
     runs-on: ubuntu-18.04
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ RUN apt-get -y install git
 RUN pip3 install poetry
 
 RUN mkdir /srv/www
-#COPY integration_test.ini unit_test.ini /srv/www/
-COPY poetry.lock pyproject.toml /srv/www/
+COPY poetry.lock pyproject.toml unit_test.ini integration_test.ini /srv/www/
 WORKDIR /srv/www
 RUN poetry config virtualenvs.create false
-RUN poetry install --no-dev
+RUN poetry install
 COPY ./democratizing/ /srv/www/democratizing/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+# Makefile for local development
+
+.PHONY: down clean nuke
+
+build:
+	@docker-compose -f docker-compose.dev.yml build
+
+# Builds core locally and then runs pgrest in daemon mode
+start: build
+	@docker-compose -f docker-compose.dev.yml up
+
+
+# Run unit tests on *unit_test.py
+unittest: build
+	@docker-compose -f docker-compose.dev.yml run server pytest -c unit_test.ini
+
+
+# Run integration tests on docker-compose.dev *integration_test.py
+integrationtest: build
+	@docker-compose -f docker-compose.dev.yml run server pytest -c integration_test.ini
+
+# Pulls all Docker images not yet available but needed to run pgrest
+pull:
+	@docker-compose -f docker-compose.dev.yml pull
+
+
+# Ends all active Docker containers needed for pgrest
+down:
+	@docker-compose -f docker-compose.dev.yml down
+
+# Ends all active Docker containers needed for pgrest and clears all volumes
+# If this is not used the postgres container will restart with data
+down-volumes:
+	@docker-compose down
+	@docker volume prune -f
+
+
+# Does a clean and also deletes all images needed for abaco
+clean:
+	@docker-compose down --remove-orphans -v --rmi all 
+
+
+# Deletes ALL images, containers, and volumes forcefully
+nuke:
+	@docker rm -f `docker ps -aq`
+	@docker rmi -f `docker images -aq`
+	@docker container prune -f
+	@docker volume prune -f

--- a/democratizing/conftest.py
+++ b/democratizing/conftest.py
@@ -3,7 +3,10 @@ from unittest.mock import MagicMock
 from fastapi.testclient import TestClient
 from democratizing.dependencies import get_db
 from democratizing.main import app
-from democratizing import models
+from democratizing import models, schemas
+from democratizing.database import SessionLocal
+import os
+import json
 
 
 @pytest.fixture
@@ -42,3 +45,14 @@ def mock_publication_model():
         "fw_citation_impact": 3.8,
     }
     yield models.Publication(**entry)
+
+
+@pytest.fixture
+def integration_db_session():
+    yield SessionLocal()
+
+
+@pytest.fixture
+def topic_schema():
+    with open(os.path.join(os.path.dirname(__file__), "fixtures/topic.json"), "r") as f:
+        yield schemas.Topic(**json.load(f))

--- a/democratizing/conftest.py
+++ b/democratizing/conftest.py
@@ -5,6 +5,7 @@ from democratizing.dependencies import get_db
 from democratizing.main import app
 from democratizing import models, schemas
 from democratizing.database import SessionLocal
+from pydantic import BaseModel
 import os
 import json
 
@@ -52,7 +53,16 @@ def integration_db_session():
     yield SessionLocal()
 
 
+def load_schema_from_fixture(schema: BaseModel, fixture: str):
+    with open(os.path.join(os.path.dirname(__file__), f"fixtures/{fixture}"), "r") as f:
+        return schema(**json.load(f))
+
+
 @pytest.fixture
 def topic_schema():
-    with open(os.path.join(os.path.dirname(__file__), "fixtures/topic.json"), "r") as f:
-        yield schemas.Topic(**json.load(f))
+    yield load_schema_from_fixture(schemas.Topic, "topic.json")
+
+
+@pytest.fixture
+def publication_schema():
+    yield load_schema_from_fixture(schemas.Publication, "publication.json")

--- a/democratizing/fixtures/publication.json
+++ b/democratizing/fixtures/publication.json
@@ -1,0 +1,13 @@
+{
+  "id": 1,
+  "run_id": 1,
+  "journal_id": 1,
+  "external_id": "2-s2.0-85044126912",
+  "title": "Black carbon and ozone variability at the kathmandu valley and at the southern himalayas: A comparison between a “Hot Spot” and a downwind high-altitude site",
+  "doi": "10.4209/aaqr.2017.04.0138",
+  "year": 2018,
+  "month": 3,
+  "pub_type": "Article",
+  "citation_count": 11,
+  "fw_citation_impact": 0.6
+}

--- a/democratizing/fixtures/topic.json
+++ b/democratizing/fixtures/topic.json
@@ -1,0 +1,8 @@
+{
+  "id": 1,
+  "run_id": 1,
+  "keywords": "Acidobacteria|Chloroflexus|Nitrospirae",
+  "external_topic_id": "11531",
+  "prominence": 99.4000015258789,
+  "last_updated_date": "2022-07-08T13:45:06.110000"
+}

--- a/democratizing/publications/tests/publications_integration_test.py
+++ b/democratizing/publications/tests/publications_integration_test.py
@@ -1,0 +1,7 @@
+from democratizing.publications.crud import get_publications
+from democratizing.schemas import Publication
+
+
+def test_get_topics(integration_db_session, publication_schema):
+    result = Publication.from_orm(get_publications(1, 0, integration_db_session)[0])
+    assert result == publication_schema

--- a/democratizing/topics/tests/topics_integration_test.py
+++ b/democratizing/topics/tests/topics_integration_test.py
@@ -1,0 +1,7 @@
+from democratizing.topics.crud import get_topics
+from democratizing.schemas import Topic
+
+
+def test_get_topics(integration_db_session, topic_schema):
+    result = Topic.from_orm(get_topics(1, 0, integration_db_session)[0])
+    assert result == topic_schema

--- a/democratizing/topics/tests/topics_integration_test.py
+++ b/democratizing/topics/tests/topics_integration_test.py
@@ -1,7 +1,14 @@
-from democratizing.topics.crud import get_topics
-from democratizing.schemas import Topic
+from democratizing.topics.crud import get_topics, get_topic_publications
+from democratizing.schemas import Topic, Publication
 
 
 def test_get_topics(integration_db_session, topic_schema):
     result = Topic.from_orm(get_topics(1, 0, integration_db_session)[0])
     assert result == topic_schema
+
+
+def test_get_topic_publications(integration_db_session, topic_schema):
+    result = Publication.from_orm(
+        get_topic_publications(1, 1, 0, integration_db_session)[0]
+    )
+    assert result.id is not None

--- a/integration_test.ini
+++ b/integration_test.ini
@@ -1,0 +1,3 @@
+[pytest]
+python_files =
+  *integration_test.py

--- a/unit_test.ini
+++ b/unit_test.ini
@@ -1,0 +1,3 @@
+[pytest]
+python_files =
+  *unit_test.py


### PR DESCRIPTION
## Overview:

Integration Tests for current /topics and /publications endpoints

## Related Github Issues:

- [DDA-0007](https://github.com/DemocratizingData/democratizingdata-api/issues/0007)

## Summary of Changes:

- unit test and integration test ini files for pytest
- Makefile with `make unittest` and `make integrationtests`
- test fixtures for topic and publications

## Testing Steps:

1. `make unittest`
2. `make integrationtest`

## UI Photos:

## Notes:
