### PR TITLE
task/DDA-0013 -- pagination params dependency

### DIFF
--- a/democratizing/dependencies.py
+++ b/democratizing/dependencies.py
@@ -1,4 +1,10 @@
 from democratizing.database import SessionLocal
+from pydantic import BaseModel
+
+
+class PaginationParams(BaseModel):
+    limit: int | None
+    offset: int | None
 
 
 def get_db():
@@ -7,3 +13,9 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+def get_pagination_params(
+    limit: int | None = None, offset: int | None = None
+) -> PaginationParams:
+    return PaginationParams(limit=limit, offset=offset)

--- a/democratizing/publications/crud.py
+++ b/democratizing/publications/crud.py
@@ -1,10 +1,11 @@
 from democratizing.models import Publication
 from democratizing.utils import apply_limit_offset
+from democratizing.dependencies import PaginationParams
 from sqlalchemy.orm import Session
 import logging
 
 logger = logging.getLogger()
 
 
-def get_publications(limit: int | None, offset: int | None, db: Session):
-    return apply_limit_offset(db.query(Publication), limit, offset).all()
+def get_publications(pagination: PaginationParams, db: Session):
+    return apply_limit_offset(db.query(Publication), pagination).all()

--- a/democratizing/publications/crud.py
+++ b/democratizing/publications/crud.py
@@ -1,5 +1,5 @@
 from democratizing.models import Publication
-from democratizing.utils import apply_limit_offset
+from democratizing.utils import apply_pagination
 from democratizing.dependencies import PaginationParams
 from sqlalchemy.orm import Session
 import logging
@@ -8,4 +8,4 @@ logger = logging.getLogger()
 
 
 def get_publications(pagination: PaginationParams, db: Session):
-    return apply_limit_offset(db.query(Publication), pagination).all()
+    return apply_pagination(db.query(Publication), pagination).all()

--- a/democratizing/publications/router.py
+++ b/democratizing/publications/router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 import logging
-from democratizing import schemas, dependencies
+from democratizing import schemas
+from democratizing.dependencies import get_db, get_pagination_params, PaginationParams
 from democratizing.publications import crud
 from sqlalchemy.orm import Session
 
@@ -19,8 +20,7 @@ router = APIRouter(
 
 @router.get("", response_model=list[schemas.Publication])
 def get_publications(
-    limit: int | None = None,
-    offset: int | None = None,
-    db: Session = Depends(dependencies.get_db),
+    pagination: PaginationParams = Depends(get_pagination_params),
+    db: Session = Depends(get_db),
 ):
-    return crud.get_publications(limit, offset, db)
+    return crud.get_publications(pagination, db)

--- a/democratizing/publications/tests/publications_integration_test.py
+++ b/democratizing/publications/tests/publications_integration_test.py
@@ -1,7 +1,10 @@
 from democratizing.publications.crud import get_publications
 from democratizing.schemas import Publication
+from democratizing.dependencies import PaginationParams
 
 
 def test_get_topics(integration_db_session, publication_schema):
-    result = Publication.from_orm(get_publications(1, 0, integration_db_session)[0])
+    result = Publication.from_orm(
+        get_publications(PaginationParams(limit=1, offet=0), integration_db_session)[0]
+    )
     assert result == publication_schema

--- a/democratizing/tests/dependencies_unit_test.py
+++ b/democratizing/tests/dependencies_unit_test.py
@@ -1,0 +1,38 @@
+import pytest
+from fastapi import FastAPI, Depends, APIRouter
+from fastapi.testclient import TestClient
+from democratizing.dependencies import get_pagination_params, PaginationParams
+from unittest.mock import MagicMock
+
+
+pagination_spy = MagicMock()
+
+
+@pytest.fixture
+def dependency_test_router():
+    pagination_spy.reset_mock()
+    dependency_test_router = APIRouter(
+        prefix="/test",
+        tags=["test"],
+        responses={404: {"description": "Not found"}},
+    )
+
+    @dependency_test_router.get("")
+    def test(pagination: PaginationParams = Depends(get_pagination_params)):
+        pagination_spy(pagination)
+        return {}
+
+    yield dependency_test_router
+
+
+@pytest.fixture
+def dependency_test_client(dependency_test_router):
+    app = FastAPI()
+    app.include_router(dependency_test_router)
+    client = TestClient(app)
+    yield client
+
+
+def test_pagination_dependency(dependency_test_client):
+    dependency_test_client.get("/test?limit=20&offset=10")
+    pagination_spy.assert_called_with(PaginationParams(limit=20, offset=10))

--- a/democratizing/topics/crud.py
+++ b/democratizing/topics/crud.py
@@ -1,22 +1,20 @@
 from democratizing.models import Topic, Publication, PublicationTopic
 from sqlalchemy.orm import Session
 from democratizing.utils import apply_limit_offset
+from democratizing.dependencies import PaginationParams
 import logging
 
 logger = logging.getLogger()
 
 
-def get_topics(limit: int | None, offset: int | None, db: Session):
-    return apply_limit_offset(db.query(Topic), limit, offset).all()
+def get_topics(pagination: PaginationParams, db: Session):
+    return apply_limit_offset(db.query(Topic), pagination).all()
 
 
-def get_topic_publications(
-    topic_id: int, limit: int | None, offset: int | None, db: Session
-):
+def get_topic_publications(topic_id: int, pagination: PaginationParams, db: Session):
     return apply_limit_offset(
         db.query(Publication)
         .join(PublicationTopic)
         .filter(PublicationTopic.topic_id == topic_id),
-        limit,
-        offset,
+        pagination,
     ).all()

--- a/democratizing/topics/crud.py
+++ b/democratizing/topics/crud.py
@@ -1,6 +1,6 @@
 from democratizing.models import Topic, Publication, PublicationTopic
 from sqlalchemy.orm import Session
-from democratizing.utils import apply_limit_offset
+from democratizing.utils import apply_pagination
 from democratizing.dependencies import PaginationParams
 import logging
 
@@ -8,11 +8,11 @@ logger = logging.getLogger()
 
 
 def get_topics(pagination: PaginationParams, db: Session):
-    return apply_limit_offset(db.query(Topic), pagination).all()
+    return apply_pagination(db.query(Topic), pagination).all()
 
 
 def get_topic_publications(topic_id: int, pagination: PaginationParams, db: Session):
-    return apply_limit_offset(
+    return apply_pagination(
         db.query(Publication)
         .join(PublicationTopic)
         .filter(PublicationTopic.topic_id == topic_id),

--- a/democratizing/topics/router.py
+++ b/democratizing/topics/router.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Depends
 import logging
-from democratizing import schemas, dependencies
+from democratizing import schemas
 from democratizing.topics import crud
 from sqlalchemy.orm import Session
+from democratizing.dependencies import get_db, get_pagination_params, PaginationParams
 
 logger = logging.getLogger(__name__)
 
@@ -19,18 +20,16 @@ router = APIRouter(
 
 @router.get("", response_model=list[schemas.Topic])
 def get_topics(
-    limit: int | None = None,
-    offset: int | None = None,
-    db: Session = Depends(dependencies.get_db),
+    pagination: PaginationParams = Depends(get_pagination_params),
+    db: Session = Depends(get_db),
 ):
-    return crud.get_topics(limit, offset, db)
+    return crud.get_topics(pagination, db)
 
 
 @router.get("/{topic_id}/publications", response_model=list[schemas.Publication])
 def get_topic_publications(
     topic_id: int,
-    limit: int | None = None,
-    offset: int | None = None,
-    db: Session = Depends(dependencies.get_db),
+    pagination: PaginationParams = Depends(get_pagination_params),
+    db: Session = Depends(get_db),
 ):
-    return crud.get_topic_publications(topic_id, limit, offset, db)
+    return crud.get_topic_publications(topic_id, pagination, db)

--- a/democratizing/topics/tests/topics_integration_test.py
+++ b/democratizing/topics/tests/topics_integration_test.py
@@ -1,14 +1,19 @@
 from democratizing.topics.crud import get_topics, get_topic_publications
 from democratizing.schemas import Topic, Publication
+from democratizing.dependencies import PaginationParams
 
 
 def test_get_topics(integration_db_session, topic_schema):
-    result = Topic.from_orm(get_topics(1, 0, integration_db_session)[0])
+    result = Topic.from_orm(
+        get_topics(PaginationParams(limit=1, offset=0), integration_db_session)[0]
+    )
     assert result == topic_schema
 
 
 def test_get_topic_publications(integration_db_session, topic_schema):
     result = Publication.from_orm(
-        get_topic_publications(1, 1, 0, integration_db_session)[0]
+        get_topic_publications(
+            1, PaginationParams(limit=1, offset=0), integration_db_session
+        )[0]
     )
     assert result.id is not None

--- a/democratizing/topics/tests/topics_router_unit_test.py
+++ b/democratizing/topics/tests/topics_router_unit_test.py
@@ -1,4 +1,4 @@
-from democratizing.models import Publication, PublicationTopic, Topic
+from democratizing.models import PublicationTopic, Topic
 
 
 def test_topics(test_client, mock_db):

--- a/democratizing/utils.py
+++ b/democratizing/utils.py
@@ -1,7 +1,10 @@
-def apply_limit_offset(query, limit: int | None, offset: int | None):
+from democratizing.dependencies import PaginationParams
+
+
+def apply_limit_offset(query, pagination: PaginationParams):
     result = query
-    if limit:
-        result = result.limit(limit)
-    if offset:
-        result = result.offset(offset)
+    if pagination.limit:
+        result = result.limit(pagination.limit)
+    if pagination.offset:
+        result = result.offset(pagination.offset)
     return result

--- a/democratizing/utils.py
+++ b/democratizing/utils.py
@@ -1,7 +1,7 @@
 from democratizing.dependencies import PaginationParams
 
 
-def apply_limit_offset(query, pagination: PaginationParams):
+def apply_pagination(query, pagination: PaginationParams):
     result = query
     if pagination.limit:
         result = result.limit(pagination.limit)

--- a/poetry.lock
+++ b/poetry.lock
@@ -181,6 +181,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "mocker"
+version = "1.1.1"
+description = "Graceful platform for test doubles in Python (mocks, stubs, fakes, and dummies)."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -414,7 +422,7 @@ h11 = ">=0.8"
 [metadata]
 lock-version = "1.0"
 python-versions = "^3.10"
-content-hash = "80c83030d0359810e2758cb334f4ce706ce2290a38390fc55b8ce47f92bad5ed"
+content-hash = "f2b8be2da924b2091d26e51a98295145dec1faa5719ebcfc17668fc3e4990b28"
 
 [metadata.files]
 anyio = [
@@ -545,6 +553,7 @@ iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
+mocker = []
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ requests = "^2.28.1"
 [tool.poetry.dev-dependencies]
 black = "^22.1.0"
 pytest = "^7.0.1"
+mocker = "^1.1.1"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
## Overview:

Adds a common pagination params dependency to simplify writing routes that support pagination

## Related Github Issues:

- [DDA-0013](https://github.com/DemocratizingData/democratizingdata-api/issues/0013)

## Summary of Changes:

- PaginationParams model and get_pagination_params dependency
- Update existing routes and tests to use this dependency

## Testing Steps:

1. make start
2. browse localhost:8000/docs to see that pagination parameters are available
3. curl http://localhost:8000/topics
4. curl http://localhost:8000/topics?limit=20&offset=10
5. curl http://localhost:8000/publications?limit=20&offset=10
6. curl http://localhost:8000/topics/1/publications?limit=20

## UI Photos:

## Notes:
